### PR TITLE
aws_iam_user_policy now respect 'enable' flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "s3_user" {
 }
 
 resource "aws_iam_user_policy" "default" {
+  count  = "${var.enabled == "true" ? 1 : 0}"
   name   = "${module.s3_user.user_name}"
   user   = "${module.s3_user.user_name}"
   policy = "${data.aws_iam_policy_document.default.json}"


### PR DESCRIPTION
## What
* respect `enabled` flag for `aws_iam_user_policy` resource

## Why
* if user disabled, no need to create `aws_iam_user_policy`. Otherwise it will fail with `- minimum field size of 1, PutUserPolicyInput.UserName.` error.