### PR TITLE
aws_iam_policy_document data also respect 'enabled' flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 data "aws_iam_policy_document" "default" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" ? 1 : 0}"
+
   statement {
     actions   = ["${var.s3_actions}"]
     resources = ["${var.s3_resources}"]

--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,5 @@ resource "aws_iam_user_policy" "default" {
   count  = "${var.enabled == "true" ? 1 : 0}"
   name   = "${module.s3_user.user_name}"
   user   = "${module.s3_user.user_name}"
-  policy = "${data.aws_iam_policy_document.default.json}"
+  policy = "${join("", data.aws_iam_policy_document.default.*.json)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 data "aws_iam_policy_document" "default" {
+  count  = "${var.enabled == "true" ? 1 : 0}"
   statement {
     actions   = ["${var.s3_actions}"]
     resources = ["${var.s3_resources}"]


### PR DESCRIPTION
## What
* respect enabled flag for aws_iam_policy_document data
## Why
* if user disabled, no need to read aws_iam_policy_document