### PR TITLE
Bump iam-system-user to 0.4.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_user" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.3.3"
+  source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.4.0"
   namespace     = "${var.namespace}"
   stage         = "${var.stage}"
   name          = "${var.name}"


### PR DESCRIPTION
To ensure we don’t output IAM secret keys when creating via Terraform 
(think: Atlantis)