### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_user" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.14.0"
+  source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.16.0"
   namespace     = var.namespace
   stage         = var.stage
   environment   = var.environment

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version

## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project

## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions
https://github.com/cloudposse/terraform-aws-iam-system-user/pull/33

