### PR TITLE
Loosen the requirements on local and null

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable -->
 # terraform-aws-iam-s3-user [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-iam-s3-user.svg)](https://github.com/cloudposse/terraform-aws-iam-s3-user/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+<!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
 
@@ -106,8 +108,8 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 
@@ -298,8 +300,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
+<!-- markdownlint-disable -->
 |  [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] |
 |---|---|---|
+<!-- markdownlint-restore -->
 
   [aknysh_homepage]: https://github.com/aknysh
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,8 @@
 |------|---------|
 | terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws   = ">= 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }


### PR DESCRIPTION
This brings the module in-line with TF recommendations on version pinning in modules.

This fixes fun issues like:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/null:
no available releases match the given constraints >= 2.0.*, ~> 2.0, >= 2.0.*
```

## what
* Allow the module to work with newer providers
* Note:  To fix the s3 bucket module, a version bump will be needed after this is merged & released [cloudposse/terraform-aws-s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket)
## why
* Addresses being unable to initialize an upstream user of this module, cloudposse/s3-bucket/aws (which appears to be broken as of 0.25.0)

## references
* https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions
* Fixes #24
