### PR TITLE
Fix wrong usage of the module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ module "s3_user" {
   stage        = "test"
   name         = "app"
   s3_actions   = ["s3:GetObject"]
-  s3_resources = "arn:aws:s3:::examplebucket/*"
+  s3_resources = ["arn:aws:s3:::examplebucket/*"]
 }
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -74,7 +74,7 @@ usage: |-
     stage        = "test"
     name         = "app"
     s3_actions   = ["s3:GetObject"]
-    s3_resources = "arn:aws:s3:::examplebucket/*"
+    s3_resources = ["arn:aws:s3:::examplebucket/*"]
   }
   ```
 include:


### PR DESCRIPTION
## what

The example usage of the module in the project's README as an error where the value of `s3_resources` is a string rather than a list(string). 

## why

This change fixes it as new users of the module are likely to copy this code and get an error



<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->



<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

Type of the `s3_resources` variable:
https://github.com/cloudposse/terraform-aws-iam-s3-user/blob/cd492ae7521a4c41b7ae8df10a340c44765ea306/variables.tf#L8C7-L8C7

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
